### PR TITLE
release-2.4.0-beta.1

### DIFF
--- a/changes/1.added
+++ b/changes/1.added
@@ -1,1 +1,0 @@
-Added tests for the current implementation of the functions

--- a/changes/1.fixed
+++ b/changes/1.fixed
@@ -1,1 +1,0 @@
-Fixed nautobot_database_ready_callback to wait for the database initialization of dependent apps before running the callback. This ensures that the callback is only run once the database is fully initialized and ready for use.

--- a/changes/2.fixed
+++ b/changes/2.fixed
@@ -1,2 +1,0 @@
-Fixed Read The Docs build error
-Fixed the test case for the version check

--- a/docs/admin/release_notes/version_2.4.md
+++ b/docs/admin/release_notes/version_2.4.md
@@ -1,102 +1,23 @@
-# v2.4.0 Release Notes
 
-!!! warning "Developer Note - Remove Me!"
-    Guiding Principles:
+# v2.4 Release Notes
 
-    - Changelogs are for humans, not machines.
-    - There should be an entry for every single version.
-    - The same types of changes should be grouped.
-    - Versions and sections should be linkable.
-    - The latest version comes first.
-    - The release date of each version is displayed.
-    - Mention whether you follow Semantic Versioning.
-
-    Types of changes:
-
-    - `Added` for new features.
-    - `Changed` for changes in existing functionality.
-    - `Deprecated` for soon-to-be removed features.
-    - `Removed` for now removed features.
-    - `Fixed` for any bug fixes.
-    - `Security` in case of vulnerabilities.
-
-
-This document describes all new features and changes in the release `2.4`. The format is based on [Keep a Changelog](https://keepachangelog.com/en/2.4.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+This document describes all new features and changes in the release. The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Release Overview
 
-- First release of the Nautobot LiveData plugin
-- Achieved in this `2.4` release
+- Major features or milestones
 - Changes to compatibility with Nautobot and/or other apps, libraries etc.
 
-## [v2.4.0b2] - 2025-02-13
+## [v2.4.0b1 (2025-02-15)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.0b1)
 
 ### Added
 
-- Tests for the LiveData plugin
-
-### Changed
-
-- Updated the README
+- [#1](https://github.com/jifox/nautobot-app-livedata/issues/1) - Added tests for the current implementation of the functions
 
 ### Fixed
 
-- Fixed all the failing tests
-
-### Deprecated
-
-### Removed
-
-## [v2.4.0b01] - 2025-02-01
-
-### Added
-
-- First release of the Nautobot LiveData plugin
-
-### Changed
-
-### Fixed
-
-### Deprecated
-
-### Removed
-
-### Security
-
-### Developer Notes
-
-- Setting `NAUTOBOT_TEST_FACTORY_SEED=stable_test_database_records`
-
-    Added to the file `development/development.env` to allow for the use of stable test database records when running tests. This setting is only used when running tests and should not be used in production environments.
-
-- Debugging Nautobot Tests
-
-    To allow debugging tests during executing in docker container the library `debugpy` is used to wait for attaching the debugger.
-
-    To enable the debugging functionality add the following code snippets:
-
-    ```python
-    from django.test import TestCase
-
-    from .conftest import wait_for_debugger_connection
-
-    class YourTest(TestCase):
-        """Test the ContentTypeUtils class."""
-
-        @classmethod
-        def setUpTestData(cls):
-            """Set up test data."""
-            wait_for_debugger_connection()  # To enable set env REMOTE_TEST_DEBUG_ENABLE=True
-
-        def setUp(self):
-            """Set up test data."""
-    ```
-
-    Run your tests with the following commands:
-
-    ```bash
-    invoke cli
-
-    # root@be0d56e917f9:/source# 
-    REMOTE_TEST_DEBUG_ENABLE=True nautobot test --keepdb nautobot_app_livedata
-    ```
+- [#1](https://github.com/jifox/nautobot-app-livedata/issues/1) - Fixed nautobot_database_ready_callback to wait for the database initialization of dependent apps before running the callback. This ensures that the callback is only run once the database is fully initialized and ready for use.
+- [#2](https://github.com/jifox/nautobot-app-livedata/issues/2) - Fixed Read The Docs build error
+- [#2](https://github.com/jifox/nautobot-app-livedata/issues/2) - Fixed the test case for the version check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,8 @@ directory = "changes"
 filename = "docs/admin/release_notes/version_X.Y.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
-issue_format = "[#{issue}](https://github.com/jifox/nautobot-app-livedata.git/issues/{issue})"
+issue_format = "[#{issue}](https://github.com/jifox/nautobot-app-livedata/issues/{issue})"
+environment = { DJANGO_SETTINGS_MODULE = "development.nautobot_config" }
 
 [[tool.towncrier.type]]
 directory = "security"


### PR DESCRIPTION

# v2.4 Release Notes

This document describes all new features and changes in the release. The format is based on [Keep a
Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic
Versioning](https://semver.org/spec/v2.0.0.html).

## Release Overview

- Major features or milestones
- Changes to compatibility with Nautobot and/or other apps, libraries etc.

## [v2.4.0b1 (2025-02-15)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.0b1)

### Added

- [#1](https://github.com/jifox/nautobot-app-livedata/issues/1) - Added tests for the current implementation of the functions

### Fixed

- [#1](https://github.com/jifox/nautobot-app-livedata/issues/1) - Fixed nautobot_database_ready_callback to wait for the database initialization of dependent apps before running the callback. This ensures that the callback is only run once the database is fully initialized and ready for use.
- [#2](https://github.com/jifox/nautobot-app-livedata/issues/2) - Fixed Read The Docs build error
- [#2](https://github.com/jifox/nautobot-app-livedata/issues/2) - Fixed the test case for the version check
