### PR TITLE
29-Allow-Live_Data-Tab-forsuperuser

### DIFF
--- a/changes/29.fixed
+++ b/changes/29.fixed
@@ -1,0 +1,1 @@
+#29 Updated permissions for the "Live Data" tab view to grant access to superusers.

--- a/nautobot_app_livedata/views.py
+++ b/nautobot_app_livedata/views.py
@@ -31,5 +31,8 @@ class LivedataInterfaceExtraTabView(ObjectView):
         extra_context["now"] = now.strftime("%Y-%m-%d %H:%M:%S")
         permissions = request.user.get_all_permissions()
         extra_context["permissions"] = permissions
-        extra_context["has_permission"] = "dcim.can_interact_device" in permissions and "extras.run_job" in permissions
+        if request.user.is_staff or request.user.is_superuser:
+            extra_context["has_permission"] = True
+        else:
+            extra_context["has_permission"] = "dcim.can_interact_device" in permissions and "extras.run_job" in permissions
         return extra_context


### PR DESCRIPTION
# Closes: #29

## What's Changed

Updated permissions for the "Live Data" tab view to grant access to superusers.
