### PR TITLE
21-Trim-the-Platform-Livedata-Show-Commands

### DIFF
--- a/changes/21.fixed
+++ b/changes/21.fixed
@@ -1,0 +1,1 @@
+#21 Remove trailing spaces from each line of livedata show commands

--- a/nautobot_app_livedata/utilities/primarydevice.py
+++ b/nautobot_app_livedata/utilities/primarydevice.py
@@ -175,5 +175,7 @@ def get_livedata_commands_for_interface(interface) -> List[str]:
     interface_commands = interface.device.platform.custom_field_data[  # type: ignore
         "livedata_interface_commands"
     ].splitlines()
+    # trim trailing whitespace
+    interface_commands = [command.rstrip() for command in interface_commands]
     # Return the commands to be executed
     return interface_commands


### PR DESCRIPTION
# Closes: #21

## What's Changed

Remove trailing spaces from each line of livedata show commands