### PR TITLE
Release 2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,24 @@ Any PRs with fixes or improvements are very welcome!
 ## Questions
 
 For any questions or comments, please check the [FAQ](https://nautobot-app-livedata.readthedocs.io/en/latest/user/faq/) first. Feel free to also swing by the [Network to Code Slack](https://networktocode.slack.com/) (channel `#nautobot`), sign up [here](http://slack.networktocode.com/) if you don't have an account.
+
+# Support for Filter Commands in Live Device Output Using !! Syntax
+
+## Filter Syntax
+
+You can now append a filter command to the end of a device command using the `!!` delimiter. The string following `!!` specifies the filter operation to be applied to the command output.
+
+### Examples
+
+- `show logging | i {{intf_number}} !!EXACT:{{intf_number}}!!` — Filters the output to contain only lines that contain the interface number as a whole word (e.g., matches ` Gi1/0/1`, `1/0/1  `, `^1/0/1 `, `1/0/1$` but not `11/0/1`, `1/0/11`, `foo1/0/1bar`).
+- `show logging !!LAST:100!!` — Returns only the last 100 lines of the output.
+
+### Supported Filters
+- `!!EXACT:<pattern>!!` — Only lines that contain `<pattern>` as a whole word (ignoring leading/trailing whitespace, not matching substrings within other numbers or words)
+- `!!LAST:<N>!!` — Only the last N lines
+
+Additional filters may be added in the future.
+
+This feature provides a consistent filtering mechanism across all supported platforms, reducing the need for custom scripts or manual output parsing.
+
+---

--- a/changes/91.added
+++ b/changes/91.added
@@ -1,2 +1,0 @@
-# This file describes the change for issue #91: Support for Filter Commands in Live Device Output Using !! Syntax
-feature: Support for post-processing filter commands in live device output using the `!!` syntax (e.g., `!!EXACT:foo!!`, `!!LAST:100!!`).

--- a/changes/91.added
+++ b/changes/91.added
@@ -1,0 +1,2 @@
+# This file describes the change for issue #91: Support for Filter Commands in Live Device Output Using !! Syntax
+feature: Support for post-processing filter commands in live device output using the `!!` syntax (e.g., `!!EXACT:foo!!`, `!!LAST:100!!`).

--- a/changes/95.dependencies
+++ b/changes/95.dependencies
@@ -1,1 +1,0 @@
-Bump mkdocstrings-python from 1.13.0 to 1.16.7

--- a/changes/95.dependencies
+++ b/changes/95.dependencies
@@ -1,0 +1,1 @@
+Bump mkdocstrings-python from 1.13.0 to 1.16.7

--- a/docs/admin/install.md
+++ b/docs/admin/install.md
@@ -175,6 +175,21 @@ The following Jinja2 template variables are available to be used in the show com
 
 ![Livedata Platform Detail Screenshot](https://raw.githubusercontent.com/jifox/nautobot-app-livedata/develop/docs/images/livedata-platform-detail.png)
 
+### Filter Syntax for Platform Commands
+
+You can append a filter command to the end of a device command using the `!!` delimiter. The string following `!!` specifies the filter operation to be applied to the command output.
+
+**Examples:**
+
+- `show logging | i {{intf_number}} !!EXACT:{{intf_number}}!!` — Filters the output to contain only lines that contain the interface number as a whole word (e.g., matches ` Gi1/0/1`, `1/0/1  `, `^1/0/1 `, `1/0/1$` but not `11/0/1`, `1/0/11`, `foo1/0/1bar`).
+- `show logging !!LAST:100!!` — Returns only the last 100 lines of the output.
+
+**Supported Filters:**
+- `!!EXACT:<pattern>!!` — Only lines that contain `<pattern>` as a whole word (ignoring leading/trailing whitespace, not matching substrings within other numbers or words)
+- `!!LAST:<N>!!` — Only the last N lines
+
+This feature provides a consistent filtering mechanism across all supported platforms, reducing the need for custom scripts or manual output parsing.
+
 ## Cleanup Job
 
 The app provides a job to clean up old data. The job can be executed on a regular basis to clean up old data that is stored in the database. The job is executed via the Nautobot Scheduler.

--- a/docs/admin/release_notes/version_2.4.md
+++ b/docs/admin/release_notes/version_2.4.md
@@ -10,6 +10,17 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Major features or milestones
 - Changes to compatibility with Nautobot and/or other apps, libraries etc.
 
+## [v2.4.1 (2025-06-19)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.1)
+
+### Added
+
+- [#91](https://github.com/jifox/nautobot-app-livedata/issues/91) - # This file describes the change for issue #91: Support for Filter Commands in Live Device Output Using !! Syntax
+- [#91](https://github.com/jifox/nautobot-app-livedata/issues/91) - feature: Support for post-processing filter commands in live device output using the `!!` syntax (e.g., `!!EXACT:foo!!`, `!!LAST:100!!`).
+
+### Dependencies
+
+- [#95](https://github.com/jifox/nautobot-app-livedata/issues/95) - Bump mkdocstrings-python from 1.13.0 to 1.16.7
+
 ## [v2.4.1a0 (2025-06-08)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.1a0)
 
 No significant changes.
@@ -33,17 +44,6 @@ No significant changes.
 - [#69](https://github.com/jifox/nautobot-app-livedata/issues/69) - Bump mkdocstrings from 0.27.0 to 0.29.1
 - [#75](https://github.com/jifox/nautobot-app-livedata/issues/75) - Supported python Versions set to ">=3.9.2,<3.13"
 - [#89](https://github.com/jifox/nautobot-app-livedata/issues/89) - Bump ruff from 0.8.6 to 0.11.12
-
-# v2.4 Release Notes
-
-This document describes all new features and changes in the release. The format is based on [Keep a
-Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic
-Versioning](https://semver.org/spec/v2.0.0.html).
-
-## Release Overview
-
-- Major features or milestones
-- Changes to compatibility with Nautobot and/or other apps, libraries etc.
 
 ## [v2.4.0 (2025-03-20)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.0)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,5 @@ mkdocs==1.6.1
 mkdocs-material==9.6.14
 markdown-version-annotations==1.0.1
 griffe==1.5.7
-mkdocstrings-python==1.13.0
+mkdocstrings-python==1.16.7
 mkdocstrings==0.29.1

--- a/nautobot_app_livedata/utilities/output_filter.py
+++ b/nautobot_app_livedata/utilities/output_filter.py
@@ -1,0 +1,32 @@
+"""
+Output filtering utilities for Nautobot App Livedata.
+
+Provides functions to apply post-processing filters to device command output, such as EXACT and LAST filters.
+"""
+
+import re
+
+
+def apply_output_filter(output: str, filter_instruction: str) -> str:
+    """
+    Apply a filter to the output string based on the filter_instruction.
+    Supported filters:
+      - EXACT:<pattern>: Only lines that contain <pattern> as a whole word (ignoring leading/trailing whitespace)
+      - LAST:<N>: Only the last N lines
+    """
+    if not filter_instruction:
+        return output
+    if filter_instruction.startswith("EXACT:"):
+        pattern = filter_instruction[len("EXACT:") :].strip()
+        # Match pattern as a whole word, ignoring leading/trailing whitespace
+        regex = re.compile(rf"(^|\s){re.escape(pattern)}(\s|$)")
+        return "\n".join(line for line in output.splitlines() if regex.search(line.strip()))
+    if filter_instruction.startswith("LAST:"):
+        n_str = filter_instruction[len("LAST:") :]
+        try:
+            n = int(n_str)
+        except ValueError:
+            return output
+        return "\n".join(output.splitlines()[-n:])
+    # Unknown filter, return output unchanged
+    return output

--- a/poetry.lock
+++ b/poetry.lock
@@ -49,13 +49,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "application-properties"
-version = "0.8.2"
+version = "0.8.3"
 description = "A simple, easy to use, unified manner of accessing program properties."
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.9.0"
 files = [
-    {file = "application_properties-0.8.2-py3-none-any.whl", hash = "sha256:a4fe684e4d95fc45054d3316acf763a7b0f29342ccea02eee09de53004f0139c"},
-    {file = "application_properties-0.8.2.tar.gz", hash = "sha256:e5e6918c8e29ab57175567d51dfa39c00a1d75b3205625559bb02250f50f0420"},
+    {file = "application_properties-0.8.3-py3-none-any.whl", hash = "sha256:7913ac84408051f095e19e72eda3cba627c3a14d25737620dfb05cbedddb992d"},
+    {file = "application_properties-0.8.3.tar.gz", hash = "sha256:aabb54e26cdc37ba73f5b02ef453b7738cca94468f706c8522876a08164c188a"},
 ]
 
 [package.dependencies]
@@ -340,13 +340,13 @@ zstd = ["zstandard (==0.22.0)"]
 
 [[package]]
 name = "certifi"
-version = "2025.4.26"
+version = "2025.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"},
-    {file = "certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"},
+    {file = "certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057"},
+    {file = "certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"},
 ]
 
 [[package]]
@@ -2287,13 +2287,13 @@ files = [
 
 [[package]]
 name = "mkdocs-include-markdown-plugin"
-version = "7.1.5"
+version = "7.1.6"
 description = "Mkdocs Markdown includer plugin."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "mkdocs_include_markdown_plugin-7.1.5-py3-none-any.whl", hash = "sha256:d0b96edee45e7fda5eb189e63331cfaf1bf1fbdbebbd08371f1daa77045d3ae9"},
-    {file = "mkdocs_include_markdown_plugin-7.1.5.tar.gz", hash = "sha256:a986967594da6789226798e3c41c70bc17130fadb92b4313f42bd3defdac0adc"},
+    {file = "mkdocs_include_markdown_plugin-7.1.6-py3-none-any.whl", hash = "sha256:7975a593514887c18ecb68e11e35c074c5499cfa3e51b18cd16323862e1f7345"},
+    {file = "mkdocs_include_markdown_plugin-7.1.6.tar.gz", hash = "sha256:a0753cb82704c10a287f1e789fc9848f82b6beb8749814b24b03dd9f67816677"},
 ]
 
 [package.dependencies]
@@ -2790,13 +2790,13 @@ textfsm = ">=1.1.0,<2.0.0"
 
 [[package]]
 name = "oauthlib"
-version = "3.2.2"
+version = "3.3.0"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca"},
-    {file = "oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"},
+    {file = "oauthlib-3.3.0-py3-none-any.whl", hash = "sha256:a2b3a0a2a4ec2feb4b9110f56674a39b2cc2f23e14713f4ed20441dfba14e934"},
+    {file = "oauthlib-3.3.0.tar.gz", hash = "sha256:4e707cf88d7dfc22a8cce22ca736a2eef9967c1dd3845efc0703fc922353eeb2"},
 ]
 
 [package.extras]
@@ -4524,13 +4524,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.4.0"
+version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
-    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
+    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
+    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
 ]
 
 [package.extras]

--- a/poetry.lock
+++ b/poetry.lock
@@ -818,13 +818,13 @@ profile = ["gprof2dot (>=2022.7.29)"]
 
 [[package]]
 name = "django"
-version = "4.2.22"
+version = "4.2.23"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "django-4.2.22-py3-none-any.whl", hash = "sha256:0a32773b5b7f4e774a155ee253ab24a841fed7e9e9061db08bf2ce9711da404d"},
-    {file = "django-4.2.22.tar.gz", hash = "sha256:e726764b094407c313adba5e2e866ab88f00436cad85c540a5bf76dc0a912c9e"},
+    {file = "django-4.2.23-py3-none-any.whl", hash = "sha256:dafbfaf52c2f289bd65f4ab935791cb4fb9a198f2a5ba9faf35d7338a77e9803"},
+    {file = "django-4.2.23.tar.gz", hash = "sha256:42fdeaba6e6449d88d4f66de47871015097dc6f1b87910db00a91946295cfae4"},
 ]
 
 [package.dependencies]
@@ -1296,13 +1296,13 @@ doc = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
 name = "faker"
-version = "37.3.0"
+version = "37.4.0"
 description = "Faker is a Python package that generates fake data for you."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "faker-37.3.0-py3-none-any.whl", hash = "sha256:48c94daa16a432f2d2bc803c7ff602509699fca228d13e97e379cd860a7e216e"},
-    {file = "faker-37.3.0.tar.gz", hash = "sha256:77b79e7a2228d57175133af0bbcdd26dc623df81db390ee52f5104d46c010f2f"},
+    {file = "faker-37.4.0-py3-none-any.whl", hash = "sha256:cb81c09ebe06c32a10971d1bbdb264bb0e22b59af59548f011ac4809556ce533"},
+    {file = "faker-37.4.0.tar.gz", hash = "sha256:7f69d579588c23d5ce671f3fa872654ede0e67047820255f43a4aa1925b89780"},
 ]
 
 [package.dependencies]
@@ -2423,19 +2423,20 @@ python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 
 [[package]]
 name = "mkdocstrings-python"
-version = "1.13.0"
+version = "1.16.7"
 description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "mkdocstrings_python-1.13.0-py3-none-any.whl", hash = "sha256:b88bbb207bab4086434743849f8e796788b373bd32e7bfefbf8560ac45d88f97"},
-    {file = "mkdocstrings_python-1.13.0.tar.gz", hash = "sha256:2dbd5757e8375b9720e81db16f52f1856bf59905428fd7ef88005d1370e2f64c"},
+    {file = "mkdocstrings_python-1.16.7-py3-none-any.whl", hash = "sha256:a5589a5be247a28ba651287f83630c69524042f8055d93b5c203d804a3409333"},
+    {file = "mkdocstrings_python-1.16.7.tar.gz", hash = "sha256:cdfc1a99fe5f6f0d90446a364ef7cac12014a4ef46114b2677a58cec84007117"},
 ]
 
 [package.dependencies]
 griffe = ">=0.49"
-mkdocs-autorefs = ">=1.2"
-mkdocstrings = ">=0.26"
+mkdocs-autorefs = ">=1.4"
+mkdocstrings = ">=0.28.3"
+typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "napalm"
@@ -2470,19 +2471,19 @@ typing-extensions = ">=4.3.0"
 
 [[package]]
 name = "nautobot"
-version = "2.4.9"
+version = "2.4.10"
 description = "Source of truth and network automation platform."
 optional = false
 python-versions = "<3.13,>=3.9.2"
 files = [
-    {file = "nautobot-2.4.9-py3-none-any.whl", hash = "sha256:452e8d96fdd4691719232a506dbf065d8e7e1d1b2e78f90a08cbf4187e7a2e82"},
-    {file = "nautobot-2.4.9.tar.gz", hash = "sha256:377b94cdf00d023e864062f15d20a5ada0ee2a0340285ff7a333151ad25ee1b1"},
+    {file = "nautobot-2.4.10-py3-none-any.whl", hash = "sha256:45c6f500bfee017821741a129cad3187a191caecdaa60a146c18ded31c280cae"},
+    {file = "nautobot-2.4.10.tar.gz", hash = "sha256:628a7cb7a0d6e470d213bfa5409196e95133b9bb8d15b2262a514296ecefa0ce"},
 ]
 
 [package.dependencies]
 celery = ">=5.3.6,<5.4.0"
 cryptography = ">=44.0.3,<44.1.0"
-Django = ">=4.2.21,<4.3.0"
+Django = ">=4.2.22,<4.3.0"
 django-ajax-tables = ">=1.1.1,<1.2.0"
 django-celery-beat = ">=2.6.0,<2.7.0"
 django-celery-results = ">=2.5.1,<2.6.0"
@@ -3662,18 +3663,18 @@ typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "requests"
-version = "2.32.3"
+version = "2.32.4"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
-    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
+    {file = "requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c"},
+    {file = "requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<4"
+charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<3"
 
@@ -3860,13 +3861,13 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "ruamel-yaml"
-version = "0.18.13"
+version = "0.18.14"
 description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "ruamel.yaml-0.18.13-py3-none-any.whl", hash = "sha256:cf9628cfdfe9d88b78429cd093aa766e9a4c69242f9f3c86ac1d9e56437e5572"},
-    {file = "ruamel.yaml-0.18.13.tar.gz", hash = "sha256:b0d5ac0a2b0b4e39d87aed00ddff26e795de6750b064da364a8d009b97ce5f26"},
+    {file = "ruamel.yaml-0.18.14-py3-none-any.whl", hash = "sha256:710ff198bb53da66718c7db27eec4fbcc9aa6ca7204e4c1df2f282b6fe5eb6b2"},
+    {file = "ruamel.yaml-0.18.14.tar.gz", hash = "sha256:7227b76aaec364df15936730efbf7d72b30c0b79b1d578bbb8e3dcb2d81f52b7"},
 ]
 
 [package.dependencies]
@@ -4666,13 +4667,13 @@ pyyaml = "*"
 
 [[package]]
 name = "zipp"
-version = "3.22.0"
+version = "3.23.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "zipp-3.22.0-py3-none-any.whl", hash = "sha256:fe208f65f2aca48b81f9e6fd8cf7b8b32c26375266b009b413d45306b6148343"},
-    {file = "zipp-3.22.0.tar.gz", hash = "sha256:dd2f28c3ce4bc67507bfd3781d21b7bb2be31103b51a4553ad7d90b84e57ace5"},
+    {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
+    {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
 ]
 
 [package.extras]
@@ -4680,7 +4681,7 @@ check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "importlib_resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
+test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
 type = ["pytest-mypy"]
 
 [extras]
@@ -4689,4 +4690,4 @@ all = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.2,<3.13"
-content-hash = "2e678e3a60034b5535553acebcec43bc77b51858f97a83a498ce56f73b8054fb"
+content-hash = "99ae565ec26fbb308343e31b20dfe98aed136fdca891ba4191459d40f3475724"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ mkdocs-section-index = "~0.3.10"
 # Automatic documentation from sources, for MkDocs
 mkdocstrings = "~0.29.1"
 # Python-specific extension to mkdocstrings
-mkdocstrings-python = "~1.13.0"
+mkdocstrings-python = "~1.16.7"
 
 # [tool.poetry.group.linting.dependencies]
 # Code static analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "nautobot_app_livedata"
 description = "Provides a live view of network data within Nautobot."
-version = "2.4.1a0"
+version = "2.4.1b1"
 authors = ["Josef Fuchs <josef.fuchs@j-fuchs.at>"]
 license = "Apache-2.0"
 homepage = "https://github.com/jifox/nautobot-app-livedata.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "nautobot_app_livedata"
 description = "Provides a live view of network data within Nautobot."
-version = "2.4.1b1"
+version = "2.4.1"
 authors = ["Josef Fuchs <josef.fuchs@j-fuchs.at>"]
 license = "Apache-2.0"
 homepage = "https://github.com/jifox/nautobot-app-livedata.git"

--- a/tests/test_output_filter.py
+++ b/tests/test_output_filter.py
@@ -1,0 +1,43 @@
+"""
+Unit tests for output filtering utilities in Nautobot App Livedata.
+"""
+
+import unittest
+
+from nautobot_app_livedata.utilities.output_filter import apply_output_filter
+
+
+class TestOutputFilter(unittest.TestCase):
+    def test_exact_filter(self):
+        output = "foo\nbar\nbaz\nfoo"
+        filtered = apply_output_filter(output, "EXACT:foo")
+        self.assertEqual(filtered, "foo\nfoo")
+
+    def test_last_filter(self):
+        output = "line1\nline2\nline3\nline4\nline5"
+        filtered = apply_output_filter(output, "LAST:2")
+        self.assertEqual(filtered, "line4\nline5")
+
+    def test_no_filter(self):
+        output = "a\nb\nc"
+        filtered = apply_output_filter(output, None)
+        self.assertEqual(filtered, output)
+
+    def test_unknown_filter(self):
+        output = "a\nb\nc"
+        filtered = apply_output_filter(output, "FOO:bar")
+        self.assertEqual(filtered, output)
+
+    def test_last_filter_invalid(self):
+        output = "a\nb\nc"
+        filtered = apply_output_filter(output, "LAST:xyz")
+        self.assertEqual(filtered, output)
+
+    def test_exact_filter_whole_word(self):
+        output = " Gi1/0/1\n1/0/1  \n^1/0/1 \n1/0/1$\n11/0/1\n1/0/11\n1/0/111\nfoo1/0/1bar\n1/0/1foo\nfoo1/0/1"
+        filtered = apply_output_filter(output, "EXACT:1/0/1")
+        self.assertEqual(filtered, " Gi1/0/1\n1/0/1  \n^1/0/1 \n1/0/1$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# v2.4 Release Notes

This document describes all new features and changes in the release. The format is based on [Keep a
Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic
Versioning](https://semver.org/spec/v2.0.0.html).

## Release Overview

- Major features or milestones
- Changes to compatibility with Nautobot and/or other apps, libraries etc.

## [v2.4.1 (2025-06-19)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.1)

### Added

- [#91](https://github.com/jifox/nautobot-app-livedata/issues/91) - feature: Support for post-processing filter commands in live device output using the `!!` syntax (e.g., `!!EXACT:foo!!`, `!!LAST:100!!`).

### Dependencies

- [#95](https://github.com/jifox/nautobot-app-livedata/issues/95) - Bump mkdocstrings-python from 1.13.0 to 1.16.7

## [v2.4.1a0 (2025-06-08)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.1a0)

No significant changes.

### Security

- [#4](https://github.com/jifox/nautobot-app-livedata/issues/4) - Bump h11 from 0.14.0 to 0.16.0 (h11 accepts some malformed Chunked-Encoding bodies)
- [#6](https://github.com/jifox/nautobot-app-livedata/issues/6) - Bump setuptools from 76.1.0 to 78.1.1 (CVE-2022-40897)

### Changed

- [#75](https://github.com/jifox/nautobot-app-livedata/issues/75) - Bump mkdocs-material from 9.5.50 to 9.6.14
- [#75](https://github.com/jifox/nautobot-app-livedata/issues/75) - Bump debugpy from 1.8.12 to 1.8.14

### Fixed

- [#6](https://github.com/jifox/nautobot-app-livedata/issues/6) - ci.yml to use valid nautobot version un unittest.

### Dependencies

- [#69](https://github.com/jifox/nautobot-app-livedata/issues/69) - Bump mkdocstrings from 0.27.0 to 0.29.1
- [#75](https://github.com/jifox/nautobot-app-livedata/issues/75) - Supported python Versions set to ">=3.9.2,<3.13"
- [#89](https://github.com/jifox/nautobot-app-livedata/issues/89) - Bump ruff from 0.8.6 to 0.11.12

## [v2.4.0 (2025-03-20)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.0)

### Security

- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Fixed Information exposure through an exception (Weakness CWE-209, CWE-497).
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Fixed Github Action Workflow does not contain permissions (Weakness CWE-275).

### Added

- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - Added a "Live Data" Tab to the Device Details page.

### Changed

- [#12](https://github.com/jifox/nautobot-app-livedata/issues/12) - Changed - Bump docker/build-push-action (5 -> 6)
- [#40](https://github.com/jifox/nautobot-app-livedata/issues/40) - Changed - Bump actions/checkout (2 -> 4)
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - The following environment variable names are changed
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - 
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - LIVEDATA_QUERY_JOB_NAME was previously LIVEDATA_INTERFACE_QUERY_JOB_NAME
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - LIVEDATA_QUERY_JOB_DESCRIPTION was previously LIVEDATA_QUERY_INTERFACE_JOB_DESCRIPTION
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - LIVEDATA_QUERY_JOB_SOFT_TIME_LIMIT was previously LIVEDATA_QUERY_INTERFACE_JOB_SOFT_TIME_LIMIT
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - LIVEDATA_QUERY_JOB_TASK_QUEUE was previously LIVEDATA_QUERY_INTERFACE_JOB_TASK_QUEUE
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - LIVEDATA_QUERY_JOB_HIDDEN was previously LIVEDATA_QUERY_INTERFACE_JOB_HIDDEN
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Changed - Updating urllib3 (1.26.20 -> 2.3.0)
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Changed - Updating httpcore (0.17.3 -> 1.0.7)
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Changed - Updating httpx (0.24.1 -> 0.27.0)
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Changed - Updating pynautobot (2.0.1 -> 2.6.1)
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Changed - Updating nornir-nautobot (3.1.0 -> 3.3.1)
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Changed - Updating nautobot-plugin-nornir (2.2.0 -> 2.2.1)
- [#58](https://github.com/jifox/nautobot-app-livedata/issues/58) - Changed - Downgrade mkdocs-material (9.6.4 -> 9.5.50)

### Removed

- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - The following environment variable names are removed
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - 
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - `LIVEDATA_INTERFACE_QUERY_JOB_NAME` use `LIVEDATA_QUERY_JOB_NAME` instead
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - `LIVEDATA_QUERY_INTERFACE_JOB_DESCRIPTION` use `LIVEDATA_QUERY_JOB_DESCRIPTION` instead
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - `LIVEDATA_QUERY_INTERFACE_JOB_SOFT_TIME_LIMIT` use `LIVEDATA_QUERY_JOB_SOFT_TIME_LIMIT` instead
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - `LIVEDATA_QUERY_INTERFACE_JOB_TASK_QUEUE` use `LIVEDATA_QUERY_JOB_TASK_QUEUE`
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - `LIVEDATA_QUERY_INTERFACE_JOB_HIDDEN` use `LIVEDATA_QUERY_JOB_HIDDEN`


## [v2.4.0b2 (2025-02-19)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.0b2)

### Security

- [#1](https://github.com/jifox/nautobot-app-livedata/issues/1) - Vulnerable OpenSSL included in cryptography wheels fixed weaknesses CWE-392, CWE-1395

### Added

- [#9](https://github.com/jifox/nautobot-app-livedata/issues/9) - Add Dependabot configuration
- [#26](https://github.com/jifox/nautobot-app-livedata/issues/26) - Automated the Towncrier change fragement creation for Dependabot PRs

### Changed

- [#2](https://github.com/jifox/nautobot-app-livedata/issues/2) - - Update Documentation
- [#32](https://github.com/jifox/nautobot-app-livedata/issues/32) - Revise App description to be more dynamic

### Fixed

- [#2](https://github.com/jifox/nautobot-app-livedata/issues/2) - Fixed build status badges in README.md and yaml syntax in `.github/dependabot.yml`
- [#21](https://github.com/jifox/nautobot-app-livedata/issues/21) - Remove trailing spaces from each line of livedata show commands
- [#29](https://github.com/jifox/nautobot-app-livedata/issues/29) - Corrected view permissions for the "Live Data" tab to ensure superusers have access
- [#37](https://github.com/jifox/nautobot-app-livedata/issues/37) - Updated site_url to point to the documentation URL.

### Dependencies

- [#14](https://github.com/jifox/nautobot-app-livedata/issues/14) - Update pymarkdownlnt from 0.9.26 to 0.9.28
- [#15](https://github.com/jifox/nautobot-app-livedata/issues/15) - Update coverage from 6.4 to 7.6.12
- [#16](https://github.com/jifox/nautobot-app-livedata/issues/16) - Update ruff from 0.8.6 to 0.9.6
- [#17](https://github.com/jifox/nautobot-app-livedata/issues/17) - Update mkdocs-include-markdown-plugin from 7.1.2 to 7.1.4.
- [#22](https://github.com/jifox/nautobot-app-livedata/issues/22) - Update mkdocs-material from 9.5.50 to 9.6.4
- [#23](https://github.com/jifox/nautobot-app-livedata/issues/23) - Update mkdocstrings from 0.27.0 to 0.28.1
- [#25](https://github.com/jifox/nautobot-app-livedata/issues/25) - Update griffe from 1.1.1 to 1.5.7
- [#32](https://github.com/jifox/nautobot-app-livedata/issues/32) - Update nautobot-plugin-nornir from 2.2.0 to 2.2.1

## [v2.4.0b1 (2025-02-15)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.0b1)

### Added

- [#1](https://github.com/jifox/nautobot-app-livedata/issues/1) - Added tests for the current implementation of the functions

### Fixed

- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - Github CI workflow for dependabot
- [#1](https://github.com/jifox/nautobot-app-livedata/issues/1) - Fixed nautobot_database_ready_callback to wait for the database initialization of dependent apps before running the callback. This ensures that the callback is only run once the database is fully initialized and ready for use.
- [#2](https://github.com/jifox/nautobot-app-livedata/issues/2) Fixed Read The Docs build error and also fixed the test case for the version check
