### PR TITLE
Feature multiple filters per line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         id: "buildx"
         uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2"  # v3.10.0
       - name: "Build"
-        uses: "docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25"  # v5.4.0
+        uses: "docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83" # v6.18.0
         with:
           builder: "${{ steps.buildx.outputs.name }}"
           context: "./"

--- a/changes/100.dependencies
+++ b/changes/100.dependencies
@@ -1,0 +1,1 @@
+Bump mkdocs-include-markdown-plugin from 7.1.5 to 7.1.6

--- a/changes/88.dependencies
+++ b/changes/88.dependencies
@@ -1,0 +1,1 @@
+Bump docker/build-push-action from 5.4.0 to 6.18.0

--- a/changes/91.added
+++ b/changes/91.added
@@ -1,2 +1,0 @@
-# This file describes the change for issue #91: Support for Filter Commands in Live Device Output Using !! Syntax
-feature: Support for post-processing filter commands in live device output using the `!!` syntax (e.g., `!!EXACT:foo!!`, `!!LAST:100!!`).

--- a/changes/91.added
+++ b/changes/91.added
@@ -1,0 +1,1 @@
+Multiple filters can be chained in a single line using `!!` as a separator, with filters applied in order.

--- a/changes/95.dependencies
+++ b/changes/95.dependencies
@@ -1,1 +1,0 @@
-Bump mkdocstrings-python from 1.13.0 to 1.16.7

--- a/docs/admin/install.md
+++ b/docs/admin/install.md
@@ -177,7 +177,9 @@ The following Jinja2 template variables are available to be used in the show com
 
 ### Filter Syntax for Platform Commands
 
-You can append a filter command to the end of a device command using the `!!` delimiter. The string following `!!` specifies the filter operation to be applied to the command output.
+You can append a filter command to the end of a device command using the `!!` delimiter. The string following `!!` specifies the filter operation to be applied to the command output. 
+
+Multiple filters can be chained in a single line by separating each filter with `!!`, for example: `show logging !!EXACT:{{intf_number}}!!LAST:10!!`. Each `!!` acts as a command terminator, and filters are applied in the order they appear.
 
 **Examples:**
 

--- a/docs/admin/install.md
+++ b/docs/admin/install.md
@@ -175,6 +175,21 @@ The following Jinja2 template variables are available to be used in the show com
 
 ![Livedata Platform Detail Screenshot](https://raw.githubusercontent.com/jifox/nautobot-app-livedata/develop/docs/images/livedata-platform-detail.png)
 
+### Filter Syntax for Platform Commands
+
+You can append a filter command to the end of a device command using the `!!` delimiter. The string following `!!` specifies the filter operation to be applied to the command output.
+
+**Examples:**
+
+- `show logging | i {{intf_number}} !!EXACT:{{intf_number}}!!` — Filters the output to contain only lines that contain the interface number as a whole word (e.g., matches ` Gi1/0/1`, `1/0/1  `, `^1/0/1 `, `1/0/1$` but not `11/0/1`, `1/0/11`, `foo1/0/1bar`).
+- `show logging !!LAST:100!!` — Returns only the last 100 lines of the output.
+
+**Supported Filters:**
+- `!!EXACT:<pattern>!!` — Only lines that contain `<pattern>` as a whole word (ignoring leading/trailing whitespace, not matching substrings within other numbers or words)
+- `!!LAST:<N>!!` — Only the last N lines
+
+This feature provides a consistent filtering mechanism across all supported platforms, reducing the need for custom scripts or manual output parsing.
+
 ## Cleanup Job
 
 The app provides a job to clean up old data. The job can be executed on a regular basis to clean up old data that is stored in the database. The job is executed via the Nautobot Scheduler.

--- a/docs/admin/release_notes/version_2.4.md
+++ b/docs/admin/release_notes/version_2.4.md
@@ -10,6 +10,17 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Major features or milestones
 - Changes to compatibility with Nautobot and/or other apps, libraries etc.
 
+## [v2.4.1 (2025-06-19)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.1)
+
+### Added
+
+- [#91](https://github.com/jifox/nautobot-app-livedata/issues/91) - # This file describes the change for issue #91: Support for Filter Commands in Live Device Output Using !! Syntax
+- [#91](https://github.com/jifox/nautobot-app-livedata/issues/91) - feature: Support for post-processing filter commands in live device output using the `!!` syntax (e.g., `!!EXACT:foo!!`, `!!LAST:100!!`).
+
+### Dependencies
+
+- [#95](https://github.com/jifox/nautobot-app-livedata/issues/95) - Bump mkdocstrings-python from 1.13.0 to 1.16.7
+
 ## [v2.4.1a0 (2025-06-08)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.1a0)
 
 No significant changes.
@@ -33,17 +44,6 @@ No significant changes.
 - [#69](https://github.com/jifox/nautobot-app-livedata/issues/69) - Bump mkdocstrings from 0.27.0 to 0.29.1
 - [#75](https://github.com/jifox/nautobot-app-livedata/issues/75) - Supported python Versions set to ">=3.9.2,<3.13"
 - [#89](https://github.com/jifox/nautobot-app-livedata/issues/89) - Bump ruff from 0.8.6 to 0.11.12
-
-# v2.4 Release Notes
-
-This document describes all new features and changes in the release. The format is based on [Keep a
-Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic
-Versioning](https://semver.org/spec/v2.0.0.html).
-
-## Release Overview
-
-- Major features or milestones
-- Changes to compatibility with Nautobot and/or other apps, libraries etc.
 
 ## [v2.4.0 (2025-03-20)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.0)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2790,13 +2790,13 @@ textfsm = ">=1.1.0,<2.0.0"
 
 [[package]]
 name = "oauthlib"
-version = "3.3.0"
+version = "3.3.1"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "oauthlib-3.3.0-py3-none-any.whl", hash = "sha256:a2b3a0a2a4ec2feb4b9110f56674a39b2cc2f23e14713f4ed20441dfba14e934"},
-    {file = "oauthlib-3.3.0.tar.gz", hash = "sha256:4e707cf88d7dfc22a8cce22ca736a2eef9967c1dd3845efc0703fc922353eeb2"},
+    {file = "oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1"},
+    {file = "oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9"},
 ]
 
 [package.extras]
@@ -3171,13 +3171,13 @@ pyasn1 = ">=0.6.1,<0.7.0"
 
 [[package]]
 name = "pycodestyle"
-version = "2.13.0"
+version = "2.14.0"
 description = "Python style guide checker"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "pycodestyle-2.13.0-py2.py3-none-any.whl", hash = "sha256:35863c5974a271c7a726ed228a14a4f6daf49df369d8c50cd9a6f58a5e143ba9"},
-    {file = "pycodestyle-2.13.0.tar.gz", hash = "sha256:c8415bf09abe81d9c7f872502a6eee881fbe85d8763dd5b9924bb0a01d67efae"},
+    {file = "pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d"},
+    {file = "pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783"},
 ]
 
 [[package]]
@@ -4690,4 +4690,4 @@ all = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9.2,<3.13"
-content-hash = "99ae565ec26fbb308343e31b20dfe98aed136fdca891ba4191459d40f3475724"
+content-hash = "c22583afe28ca10af90788d276fbd761f52673cad33efcf85c5708244efddfc2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -49,13 +49,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "application-properties"
-version = "0.8.2"
+version = "0.8.3"
 description = "A simple, easy to use, unified manner of accessing program properties."
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.9.0"
 files = [
-    {file = "application_properties-0.8.2-py3-none-any.whl", hash = "sha256:a4fe684e4d95fc45054d3316acf763a7b0f29342ccea02eee09de53004f0139c"},
-    {file = "application_properties-0.8.2.tar.gz", hash = "sha256:e5e6918c8e29ab57175567d51dfa39c00a1d75b3205625559bb02250f50f0420"},
+    {file = "application_properties-0.8.3-py3-none-any.whl", hash = "sha256:7913ac84408051f095e19e72eda3cba627c3a14d25737620dfb05cbedddb992d"},
+    {file = "application_properties-0.8.3.tar.gz", hash = "sha256:aabb54e26cdc37ba73f5b02ef453b7738cca94468f706c8522876a08164c188a"},
 ]
 
 [package.dependencies]
@@ -340,13 +340,13 @@ zstd = ["zstandard (==0.22.0)"]
 
 [[package]]
 name = "certifi"
-version = "2025.4.26"
+version = "2025.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"},
-    {file = "certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"},
+    {file = "certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057"},
+    {file = "certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"},
 ]
 
 [[package]]
@@ -2287,13 +2287,13 @@ files = [
 
 [[package]]
 name = "mkdocs-include-markdown-plugin"
-version = "7.1.5"
+version = "7.1.6"
 description = "Mkdocs Markdown includer plugin."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "mkdocs_include_markdown_plugin-7.1.5-py3-none-any.whl", hash = "sha256:d0b96edee45e7fda5eb189e63331cfaf1bf1fbdbebbd08371f1daa77045d3ae9"},
-    {file = "mkdocs_include_markdown_plugin-7.1.5.tar.gz", hash = "sha256:a986967594da6789226798e3c41c70bc17130fadb92b4313f42bd3defdac0adc"},
+    {file = "mkdocs_include_markdown_plugin-7.1.6-py3-none-any.whl", hash = "sha256:7975a593514887c18ecb68e11e35c074c5499cfa3e51b18cd16323862e1f7345"},
+    {file = "mkdocs_include_markdown_plugin-7.1.6.tar.gz", hash = "sha256:a0753cb82704c10a287f1e789fc9848f82b6beb8749814b24b03dd9f67816677"},
 ]
 
 [package.dependencies]
@@ -2790,13 +2790,13 @@ textfsm = ">=1.1.0,<2.0.0"
 
 [[package]]
 name = "oauthlib"
-version = "3.2.2"
+version = "3.3.0"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca"},
-    {file = "oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"},
+    {file = "oauthlib-3.3.0-py3-none-any.whl", hash = "sha256:a2b3a0a2a4ec2feb4b9110f56674a39b2cc2f23e14713f4ed20441dfba14e934"},
+    {file = "oauthlib-3.3.0.tar.gz", hash = "sha256:4e707cf88d7dfc22a8cce22ca736a2eef9967c1dd3845efc0703fc922353eeb2"},
 ]
 
 [package.extras]
@@ -4524,13 +4524,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.4.0"
+version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
-    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
+    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
+    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ mkdocs-gen-files = "~0.5.0"
 mkdocs-glightbox = "^0.4.0"
 # Allow Markdown files to include other files
 # 3.0 TODO: remove this, as we don't actually use it any more since 2.0?
-mkdocs-include-markdown-plugin = ">=4.0.4"
+mkdocs-include-markdown-plugin = "~7.1.6"
 # Use Jinja2 templating in docs - see settings.md
 mkdocs-macros-plugin = "~1.3.7"
 # Material for mkdocs theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "nautobot_app_livedata"
 description = "Provides a live view of network data within Nautobot."
-version = "2.4.1b1"
+version = "2.4.1"
 authors = ["Josef Fuchs <josef.fuchs@j-fuchs.at>"]
 license = "Apache-2.0"
 homepage = "https://github.com/jifox/nautobot-app-livedata.git"

--- a/tests/test_output_filter.py
+++ b/tests/test_output_filter.py
@@ -38,6 +38,18 @@ class TestOutputFilter(unittest.TestCase):
         filtered = apply_output_filter(output, "EXACT:1/0/1")
         self.assertEqual(filtered, " Gi1/0/1\n1/0/1  \n^1/0/1 \n1/0/1$")
 
+    def test_multiple_filters(self):
+        output = "foo\nbar\nfoo\nbaz\nfoo"
+        # Apply EXACT:foo, then LAST:2
+        filtered = apply_output_filter(output, "EXACT:foo!!LAST:2!!")
+        self.assertEqual(filtered, "foo\nfoo")
+        # Apply LAST:3, then EXACT:foo
+        filtered2 = apply_output_filter(output, "LAST:3!!EXACT:foo!!")
+        self.assertEqual(filtered2, "foo")
+        # Apply EXACT:foo, then LAST:1
+        filtered3 = apply_output_filter(output, "EXACT:foo!!LAST:1!!")
+        self.assertEqual(filtered3, "foo")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Nautobot App Livedata! Please note
    that our contribution policy recommends that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

# Closes: #88, #91, #100

## What's Changed

<!--
    Please include:
    - A summary of the proposed changes
    - A sectioned breakdown for larger features under ## subheadings
    - Screenshots, example payloads where relevant:
      - Before/After for bugfixes
      - Using a new feature
-->
- Bump docker/build-push-action from 5.4.0 to 6.18.0
- Multiple filters can be chained in a single line using `!!` as a separator, with filters applied in order
- Bump mkdocs-include-markdown-plugin from 7.1.5 to 7.1.6
