### PR TITLE
Release v2.4.2

### DIFF
--- a/changes/91.added
+++ b/changes/91.added
@@ -1,2 +1,0 @@
-# This file describes the change for issue #91: Support for Filter Commands in Live Device Output Using !! Syntax
-feature: Support for post-processing filter commands in live device output using the `!!` syntax (e.g., `!!EXACT:foo!!`, `!!LAST:100!!`).

--- a/changes/95.dependencies
+++ b/changes/95.dependencies
@@ -1,1 +1,0 @@
-Bump mkdocstrings-python from 1.13.0 to 1.16.7

--- a/docs/admin/install.md
+++ b/docs/admin/install.md
@@ -175,6 +175,21 @@ The following Jinja2 template variables are available to be used in the show com
 
 ![Livedata Platform Detail Screenshot](https://raw.githubusercontent.com/jifox/nautobot-app-livedata/develop/docs/images/livedata-platform-detail.png)
 
+### Filter Syntax for Platform Commands
+
+You can append a filter command to the end of a device command using the `!!` delimiter. The string following `!!` specifies the filter operation to be applied to the command output.
+
+**Examples:**
+
+- `show logging | i {{intf_number}} !!EXACT:{{intf_number}}!!` — Filters the output to contain only lines that contain the interface number as a whole word (e.g., matches ` Gi1/0/1`, `1/0/1  `, `^1/0/1 `, `1/0/1$` but not `11/0/1`, `1/0/11`, `foo1/0/1bar`).
+- `show logging !!LAST:100!!` — Returns only the last 100 lines of the output.
+
+**Supported Filters:**
+- `!!EXACT:<pattern>!!` — Only lines that contain `<pattern>` as a whole word (ignoring leading/trailing whitespace, not matching substrings within other numbers or words)
+- `!!LAST:<N>!!` — Only the last N lines
+
+This feature provides a consistent filtering mechanism across all supported platforms, reducing the need for custom scripts or manual output parsing.
+
 ## Cleanup Job
 
 The app provides a job to clean up old data. The job can be executed on a regular basis to clean up old data that is stored in the database. The job is executed via the Nautobot Scheduler.

--- a/docs/admin/release_notes/version_2.4.md
+++ b/docs/admin/release_notes/version_2.4.md
@@ -10,6 +10,17 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Major features or milestones
 - Changes to compatibility with Nautobot and/or other apps, libraries etc.
 
+## [v2.4.1 (2025-06-19)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.1)
+
+### Added
+
+- [#91](https://github.com/jifox/nautobot-app-livedata/issues/91) - # This file describes the change for issue #91: Support for Filter Commands in Live Device Output Using !! Syntax
+- [#91](https://github.com/jifox/nautobot-app-livedata/issues/91) - feature: Support for post-processing filter commands in live device output using the `!!` syntax (e.g., `!!EXACT:foo!!`, `!!LAST:100!!`).
+
+### Dependencies
+
+- [#95](https://github.com/jifox/nautobot-app-livedata/issues/95) - Bump mkdocstrings-python from 1.13.0 to 1.16.7
+
 ## [v2.4.1a0 (2025-06-08)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.1a0)
 
 No significant changes.
@@ -33,17 +44,6 @@ No significant changes.
 - [#69](https://github.com/jifox/nautobot-app-livedata/issues/69) - Bump mkdocstrings from 0.27.0 to 0.29.1
 - [#75](https://github.com/jifox/nautobot-app-livedata/issues/75) - Supported python Versions set to ">=3.9.2,<3.13"
 - [#89](https://github.com/jifox/nautobot-app-livedata/issues/89) - Bump ruff from 0.8.6 to 0.11.12
-
-# v2.4 Release Notes
-
-This document describes all new features and changes in the release. The format is based on [Keep a
-Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic
-Versioning](https://semver.org/spec/v2.0.0.html).
-
-## Release Overview
-
-- Major features or milestones
-- Changes to compatibility with Nautobot and/or other apps, libraries etc.
 
 ## [v2.4.0 (2025-03-20)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.0)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -49,13 +49,13 @@ trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "application-properties"
-version = "0.8.2"
+version = "0.8.3"
 description = "A simple, easy to use, unified manner of accessing program properties."
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.9.0"
 files = [
-    {file = "application_properties-0.8.2-py3-none-any.whl", hash = "sha256:a4fe684e4d95fc45054d3316acf763a7b0f29342ccea02eee09de53004f0139c"},
-    {file = "application_properties-0.8.2.tar.gz", hash = "sha256:e5e6918c8e29ab57175567d51dfa39c00a1d75b3205625559bb02250f50f0420"},
+    {file = "application_properties-0.8.3-py3-none-any.whl", hash = "sha256:7913ac84408051f095e19e72eda3cba627c3a14d25737620dfb05cbedddb992d"},
+    {file = "application_properties-0.8.3.tar.gz", hash = "sha256:aabb54e26cdc37ba73f5b02ef453b7738cca94468f706c8522876a08164c188a"},
 ]
 
 [package.dependencies]
@@ -340,13 +340,13 @@ zstd = ["zstandard (==0.22.0)"]
 
 [[package]]
 name = "certifi"
-version = "2025.4.26"
+version = "2025.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"},
-    {file = "certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"},
+    {file = "certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057"},
+    {file = "certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"},
 ]
 
 [[package]]
@@ -2287,13 +2287,13 @@ files = [
 
 [[package]]
 name = "mkdocs-include-markdown-plugin"
-version = "7.1.5"
+version = "7.1.6"
 description = "Mkdocs Markdown includer plugin."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "mkdocs_include_markdown_plugin-7.1.5-py3-none-any.whl", hash = "sha256:d0b96edee45e7fda5eb189e63331cfaf1bf1fbdbebbd08371f1daa77045d3ae9"},
-    {file = "mkdocs_include_markdown_plugin-7.1.5.tar.gz", hash = "sha256:a986967594da6789226798e3c41c70bc17130fadb92b4313f42bd3defdac0adc"},
+    {file = "mkdocs_include_markdown_plugin-7.1.6-py3-none-any.whl", hash = "sha256:7975a593514887c18ecb68e11e35c074c5499cfa3e51b18cd16323862e1f7345"},
+    {file = "mkdocs_include_markdown_plugin-7.1.6.tar.gz", hash = "sha256:a0753cb82704c10a287f1e789fc9848f82b6beb8749814b24b03dd9f67816677"},
 ]
 
 [package.dependencies]
@@ -2790,13 +2790,13 @@ textfsm = ">=1.1.0,<2.0.0"
 
 [[package]]
 name = "oauthlib"
-version = "3.2.2"
+version = "3.3.0"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca"},
-    {file = "oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"},
+    {file = "oauthlib-3.3.0-py3-none-any.whl", hash = "sha256:a2b3a0a2a4ec2feb4b9110f56674a39b2cc2f23e14713f4ed20441dfba14e934"},
+    {file = "oauthlib-3.3.0.tar.gz", hash = "sha256:4e707cf88d7dfc22a8cce22ca736a2eef9967c1dd3845efc0703fc922353eeb2"},
 ]
 
 [package.extras]
@@ -4524,13 +4524,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.4.0"
+version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
-    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
+    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
+    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "nautobot_app_livedata"
 description = "Provides a live view of network data within Nautobot."
-version = "2.4.1b1"
+version = "2.4.1"
 authors = ["Josef Fuchs <josef.fuchs@j-fuchs.at>"]
 license = "Apache-2.0"
 homepage = "https://github.com/jifox/nautobot-app-livedata.git"


### PR DESCRIPTION

# v2.4 Release Notes

This document describes all new features and changes in the release. The format is based on [Keep a
Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic
Versioning](https://semver.org/spec/v2.0.0.html).

### Filter Syntax for Platform Commands

You can append a filter command to the end of a device command using the `!!` delimiter. The string following `!!` specifies the filter operation to be applied to the command output. 

Multiple filters can be chained in a single line by separating each filter with `!!`, for example: `show logging !!EXACT:{{intf_number}}!!LAST:10!!`. Each `!!` acts as a command terminator, and filters are applied in the order they appear.

!!! note
    Added multiple filters in v2.4.2, this feature allows for more flexible and powerful command filtering directly in the Live Data tab.

## Release Overview

- Major features or milestones
- Changes to compatibility with Nautobot and/or other apps, libraries etc.

## [v2.4.2 (2025-06-22)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.2)

### Added

- [#91](https://github.com/jifox/nautobot-app-livedata/issues/91) - Multiple filters can be chained in a single line using `!!` as a separator, with filters applied in order.

### Dependencies

- [#88](https://github.com/jifox/nautobot-app-livedata/issues/88) - Bump docker/build-push-action from 5.4.0 to 6.18.0
- [#100](https://github.com/jifox/nautobot-app-livedata/issues/100) - Bump mkdocs-include-markdown-plugin from 7.1.5 to 7.1.6

## [v2.4.1 (2025-06-19)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.1)

### Added

- [#91](https://github.com/jifox/nautobot-app-livedata/issues/91) - # This file describes the change for issue #91: Support for Filter Commands in Live Device Output Using !! Syntax
- [#91](https://github.com/jifox/nautobot-app-livedata/issues/91) - feature: Support for post-processing filter commands in live device output using the `!!` syntax (e.g., `!!EXACT:foo!!`, `!!LAST:100!!`).

### Dependencies

- [#95](https://github.com/jifox/nautobot-app-livedata/issues/95) - Bump mkdocstrings-python from 1.13.0 to 1.16.7

## [v2.4.1a0 (2025-06-08)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.1a0)

No significant changes.

### Security

- [#4](https://github.com/jifox/nautobot-app-livedata/issues/4) - Bump h11 from 0.14.0 to 0.16.0 (h11 accepts some malformed Chunked-Encoding bodies)
- [#6](https://github.com/jifox/nautobot-app-livedata/issues/6) - Bump setuptools from 76.1.0 to 78.1.1 (CVE-2022-40897)

### Changed

- [#75](https://github.com/jifox/nautobot-app-livedata/issues/75) - Bump mkdocs-material from 9.5.50 to 9.6.14
- [#75](https://github.com/jifox/nautobot-app-livedata/issues/75) - Bump debugpy from 1.8.12 to 1.8.14

### Fixed

- [#6](https://github.com/jifox/nautobot-app-livedata/issues/6) - ci.yml to use valid nautobot version un unittest.

### Dependencies

- [#69](https://github.com/jifox/nautobot-app-livedata/issues/69) - Bump mkdocstrings from 0.27.0 to 0.29.1
- [#75](https://github.com/jifox/nautobot-app-livedata/issues/75) - Supported python Versions set to ">=3.9.2,<3.13"
- [#89](https://github.com/jifox/nautobot-app-livedata/issues/89) - Bump ruff from 0.8.6 to 0.11.12

## [v2.4.0 (2025-03-20)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.0)

### Security

- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Fixed Information exposure through an exception (Weakness CWE-209, CWE-497).
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Fixed Github Action Workflow does not contain permissions (Weakness CWE-275).

### Added

- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - Added a "Live Data" Tab to the Device Details page.

### Changed

- [#12](https://github.com/jifox/nautobot-app-livedata/issues/12) - Changed - Bump docker/build-push-action (5 -> 6)
- [#40](https://github.com/jifox/nautobot-app-livedata/issues/40) - Changed - Bump actions/checkout (2 -> 4)
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - The following environment variable names are changed
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - 
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - LIVEDATA_QUERY_JOB_NAME was previously LIVEDATA_INTERFACE_QUERY_JOB_NAME
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - LIVEDATA_QUERY_JOB_DESCRIPTION was previously LIVEDATA_QUERY_INTERFACE_JOB_DESCRIPTION
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - LIVEDATA_QUERY_JOB_SOFT_TIME_LIMIT was previously LIVEDATA_QUERY_INTERFACE_JOB_SOFT_TIME_LIMIT
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - LIVEDATA_QUERY_JOB_TASK_QUEUE was previously LIVEDATA_QUERY_INTERFACE_JOB_TASK_QUEUE
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - LIVEDATA_QUERY_JOB_HIDDEN was previously LIVEDATA_QUERY_INTERFACE_JOB_HIDDEN
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Changed - Updating urllib3 (1.26.20 -> 2.3.0)
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Changed - Updating httpcore (0.17.3 -> 1.0.7)
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Changed - Updating httpx (0.24.1 -> 0.27.0)
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Changed - Updating pynautobot (2.0.1 -> 2.6.1)
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Changed - Updating nornir-nautobot (3.1.0 -> 3.3.1)
- [#57](https://github.com/jifox/nautobot-app-livedata/issues/57) - Changed - Updating nautobot-plugin-nornir (2.2.0 -> 2.2.1)
- [#58](https://github.com/jifox/nautobot-app-livedata/issues/58) - Changed - Downgrade mkdocs-material (9.6.4 -> 9.5.50)

### Removed

- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - The following environment variable names are removed
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - 
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - `LIVEDATA_INTERFACE_QUERY_JOB_NAME` use `LIVEDATA_QUERY_JOB_NAME` instead
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - `LIVEDATA_QUERY_INTERFACE_JOB_DESCRIPTION` use `LIVEDATA_QUERY_JOB_DESCRIPTION` instead
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - `LIVEDATA_QUERY_INTERFACE_JOB_SOFT_TIME_LIMIT` use `LIVEDATA_QUERY_JOB_SOFT_TIME_LIMIT` instead
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - `LIVEDATA_QUERY_INTERFACE_JOB_TASK_QUEUE` use `LIVEDATA_QUERY_JOB_TASK_QUEUE`
- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - - `LIVEDATA_QUERY_INTERFACE_JOB_HIDDEN` use `LIVEDATA_QUERY_JOB_HIDDEN`


## [v2.4.0b2 (2025-02-19)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.0b2)

### Security

- [#1](https://github.com/jifox/nautobot-app-livedata/issues/1) - Vulnerable OpenSSL included in cryptography wheels fixed weaknesses CWE-392, CWE-1395

### Added

- [#9](https://github.com/jifox/nautobot-app-livedata/issues/9) - Add Dependabot configuration
- [#26](https://github.com/jifox/nautobot-app-livedata/issues/26) - Automated the Towncrier change fragement creation for Dependabot PRs

### Changed

- [#2](https://github.com/jifox/nautobot-app-livedata/issues/2) - - Update Documentation
- [#32](https://github.com/jifox/nautobot-app-livedata/issues/32) - Revise App description to be more dynamic

### Fixed

- [#2](https://github.com/jifox/nautobot-app-livedata/issues/2) - Fixed build status badges in README.md and yaml syntax in `.github/dependabot.yml`
- [#21](https://github.com/jifox/nautobot-app-livedata/issues/21) - Remove trailing spaces from each line of livedata show commands
- [#29](https://github.com/jifox/nautobot-app-livedata/issues/29) - Corrected view permissions for the "Live Data" tab to ensure superusers have access
- [#37](https://github.com/jifox/nautobot-app-livedata/issues/37) - Updated site_url to point to the documentation URL.

### Dependencies

- [#14](https://github.com/jifox/nautobot-app-livedata/issues/14) - Update pymarkdownlnt from 0.9.26 to 0.9.28
- [#15](https://github.com/jifox/nautobot-app-livedata/issues/15) - Update coverage from 6.4 to 7.6.12
- [#16](https://github.com/jifox/nautobot-app-livedata/issues/16) - Update ruff from 0.8.6 to 0.9.6
- [#17](https://github.com/jifox/nautobot-app-livedata/issues/17) - Update mkdocs-include-markdown-plugin from 7.1.2 to 7.1.4.
- [#22](https://github.com/jifox/nautobot-app-livedata/issues/22) - Update mkdocs-material from 9.5.50 to 9.6.4
- [#23](https://github.com/jifox/nautobot-app-livedata/issues/23) - Update mkdocstrings from 0.27.0 to 0.28.1
- [#25](https://github.com/jifox/nautobot-app-livedata/issues/25) - Update griffe from 1.1.1 to 1.5.7
- [#32](https://github.com/jifox/nautobot-app-livedata/issues/32) - Update nautobot-plugin-nornir from 2.2.0 to 2.2.1

## [v2.4.0b1 (2025-02-15)](https://github.com/jifox/nautobot-app-livedata.git/releases/tag/v2.4.0b1)

### Added

- [#1](https://github.com/jifox/nautobot-app-livedata/issues/1) - Added tests for the current implementation of the functions

### Fixed

- [#45](https://github.com/jifox/nautobot-app-livedata/issues/45) - Github CI workflow for dependabot
- [#1](https://github.com/jifox/nautobot-app-livedata/issues/1) - Fixed nautobot_database_ready_callback to wait for the database initialization of dependent apps before running the callback. This ensures that the callback is only run once the database is fully initialized and ready for use.
- [#2](https://github.com/jifox/nautobot-app-livedata/issues/2) Fixed Read The Docs build error and also fixed the test case for the version check
